### PR TITLE
Fix bug with colliding framenames

### DIFF
--- a/src/ndgmr.Collision.js
+++ b/src/ndgmr.Collision.js
@@ -128,7 +128,10 @@ this.ndgmr = this.ndgmr || {};
     if ( bitmap instanceof createjs.Bitmap ) {
       image = bitmap.image;
     } else if ( bitmap instanceof createjs.BitmapAnimation ) {
-      frameName = bitmap.currentFrame+bitmap.spriteSheet.getFrame(bitmap.currentFrame).image.src;
+	  frame = bitmap.spriteSheet.getFrame( bitmap.currentFrame )
+      frameName = frame.image.src + ':' + 
+		frame.rect.x + ':' + frame.rect.y  + ':' + 
+		frame.rect.width  + ':' + frame.rect.height // + ':' + frame.rect.regX  + ':' + frame.rect.regY 
       if ( cachedBAFrames[frameName] ) {
         image = cachedBAFrames[frameName];
       } else {


### PR DESCRIPTION
When you create two spritesheets that use the same source image ( because you want to separate the animations ) the script will fail as the wrong frame is served from cache.

The `frame index number` is not important and collides. 
`regX` and `regY` could be included in the name, but that's just stupid in my opinion, because who uses the same `sourceRect` with different origins for frames?
