### PR TITLE
Check if the intersection is less than a pixel high or wide

### DIFF
--- a/src/ndgmr.Collision.js
+++ b/src/ndgmr.Collision.js
@@ -73,7 +73,7 @@ this.ndgmr = this.ndgmr || {};
     //}
 
     intersection = checkRectCollision(bitmap1,bitmap2);
-    if ( !intersection ) {
+    if ( !intersection || intersection.width < 1 || intersection.height < 1) {
       return false;
     }
 


### PR DESCRIPTION
If the intersection is less than a pixel high or wide, `getImageData()` will (rightfully) throw the following error:

```Uncaught DOMException: Failed to execute 'getImageData' on 'CanvasRenderingContext2D': The source height is 0.```

 I guess `getImageData()` does an implicit `Math.floor()` on the `width` and `height` parameters to make sure there is actual data to return.